### PR TITLE
Initial work to support Meteor apps; fixed settings syntax error; updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,28 +51,25 @@ target can be 1. a node.js program, 2. a static folder, 3. a proxy target or 4. 
 
 options can be:
 
--gz[:trace.gz] Record a trace to gzip file, defaults to trace.gz, doesn't start the UI.
+**-gz[:trace.gz]** Record a trace to gzip file, defaults to trace.gz, doesn't start the UI. Filtering can be useful to lower the amount of incoming tracedata. Use -do and -no with either a -do:string or a -do/regex match. Use double escaped backslashes in regexps (see -nolib).
 
-Filtering can be useful to lower the amount of incoming tracedata. Use -do and -no with either a -do:string or a
--do/regex match. Use double escaped backslashes in regexps (see -nolib).
+**-do[/:]match** Only trace files where filename contains match.
 
--do[/:]match Only trace files where filename contains match.
+**-no[/:]match** Don't trace files where filename names contains match.
 
--no[/:]match Don't trace files where filename names contains match.
+**-nolib** Only see your own code. Short for: -no/jquery.* -no:require.js -no/node\\_modules
 
--nolib Only see your own code. Short for: -no/jquery.* -no:require.js -no/node\\_modules
+**-meteor** Only see your own code (Meteor apps only - use this instead of -nolib). Short for: -no/jquery.* -no/packages
 
--meteor Only see your own code (Meteor apps only - use this instead of -nolib). Short for: -no/jquery.* -no/packages
+**-noopen** Don't try to open the visualisation UI with your default browser
 
--noopen Don't try to open the visualisation UI with your default browser
+**-ui:port** Explicitly set the visualisation UI port, default is 2000
 
--ui:port Explicitly set the visualisation UI port, default is 2000
+**-tgt:port** Explicitly set the browser JS port, defaults to 2080
 
--tgt:port Explicitly set the browser JS port, defaults to 2080
+**-settings** Write a settings tracegl.json template in current dir, see settings file
 
--settings Write a settings tracegl.json template in current dir, see settings file
-
--update Update tracegl.js to the latest version, uses your token to fetch update
+**-update** Update tracegl.js to the latest version, uses your token to fetch update
 
 ## Settings file
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ options can be:
 
 -gz[:trace.gz] Record a trace to gzip file, defaults to trace.gz, doesn't start the UI.
 
-Filtering can be useful to lower the amount of incoming tracedata. Use -do and -no with either a -do:string or a 
+Filtering can be useful to lower the amount of incoming tracedata. Use -do and -no with either a -do:string or a
 -do/regex match. Use double escaped backslashes in regexps (see -nolib).
 
 -do[/:]match Only trace files where filename contains match.
@@ -61,6 +61,8 @@ Filtering can be useful to lower the amount of incoming tracedata. Use -do and -
 -no[/:]match Don't trace files where filename names contains match.
 
 -nolib Only see your own code. Short for: -no/jquery.* -no:require.js -no/node\\_modules
+
+-meteor Only see your own code (Meteor apps only - use this instead of -nolib). Short for: -no/jquery.* -no/packages
 
 -noopen Don't try to open the visualisation UI with your default browser
 
@@ -79,7 +81,7 @@ For other settings and commandline defaults traceGL supports a tracegl.json file
 Create a template tracegl.json using the -settings command, and then modify these fields:
 
 ```
-"ui":2000 Set the UI port, -ui:port commandline 
+"ui":2000 Set the UI port, -ui:port commandline
 ```
 ```
 "tgt":2080 Set the browser JS port, -tgt:port commandline
@@ -102,3 +104,6 @@ Editor integration uses a commandline call to your editor, and uses $file and $l
 ## Issues
 
 traceGL cannot instrument JavaScript coming from outside of its reach. For instance if you load jQuery from the google CDN, it cannot visualise that codeflow because it is not delivered by the traceGL proxy or static fileserver. If you keep your JS served through traceGL it should be no problem.
+
+##### Meteor issues
+Websocket connection currently not working due to traceGL proxy "Connection closed before receiving a handshake response". This means that you'll be able to trace events on the client, but all server calls will be rejected.

--- a/trace/trace_server.js
+++ b/trace/trace_server.js
@@ -153,6 +153,7 @@ define(function(require){
 			out('  ~c~-do[/:]match ~w~Only trace filenames containing match. Filters -do set first, then -no\n')
 			out('  ~c~-no[/:]match ~w~Ignore filenames containing match. Replace : with / for a regexp, use double escaped \\\\ \n')
 			out('  ~c~-nolib ~w~Short for -no/jquery.* -no:require.js -no/node\\\\_modules \n')
+			out('  ~c~-meteor ~w~Short for -no/jquery.* -no:/packages \n')
 			out('  ~c~-nocatch ~w~Don\'t create exception catching\n')
 			out('  ~c~-bind:0.0.0.0 ~w~Set the hostname to bind our external ports to, default 0.0.0.0\n')
 			out('  ~c~-ui:port ~w~Set trace UI port. default: 2000\n')
@@ -190,7 +191,10 @@ define(function(require){
 					} else {
 						fspec._no.push(a.slice(3))
 					}
-				} else if(a.indexOf('-do') == 0){
+				} else if (a == '-meteor') {
+					fspec._no.push("/jquery.*")
+					fspec._no.push("/packages")
+				}else if(a.indexOf('-do') == 0){
 					fspec._do.push(a.slice(3))
 				} else if(a.indexOf('-settings') == 0){
 					if(fs.existsSync('tracegl.json')){

--- a/trace/tracegl.json
+++ b/trace/tracegl.json
@@ -1,10 +1,10 @@
 {
-	"theme" : "dark", // other theme: light
-	"ui":2000, // UI port
-	"tgt":2080, // browser JS port
-	"do":[], // only trace files matching
-	"no":[], // ignore files matching ":match" for string or "/match" for regexp
-	"editors" : { // editor paths per platform, modify these to set up your editor
+	"theme" : "dark",
+	"ui":2000,
+	"tgt":2080,
+	"do":[],
+	"no":[],
+	"editors" : {
 		"darwin":{
 			"sublime3":{
 				"bin":"/Applications/Sublime Text 3.app/Contents/SharedSupport/bin/subl",

--- a/tracegl.js
+++ b/tracegl.js
@@ -3,7 +3,7 @@
 // |
 // | (C) Mozilla Corp
 // | licensed under MPL 2.0 http://www.mozilla.org/MPL/
-// \____________________________________________/   
+// \____________________________________________/
 
 
 define('/trace/trace_server',function(require){
@@ -26,8 +26,8 @@ define('/trace/trace_server',function(require){
 
 	// the nodejs loader
 	if(process.argv[2] && process.argv[2].indexOf('-l')==0) return nodeLoader()
-	
-	function nodeLoader(){ 
+
+	function nodeLoader(){
 		var filter = makeFilter(process.argv[2].slice(2))
 
 		var m = require('module').Module.prototype;
@@ -35,9 +35,9 @@ define('/trace/trace_server',function(require){
 		var did = 1
 		m._compile = function(content, filename){
 
-			if(filter.active && filter(filename)) 
+			if(filter.active && filter(filename))
 				return oldCompile.call(this, content, filename)
-			// lets instrument 
+			// lets instrument
 			var t = instrument(filename, content, did, filter.opt)
 			did = t.id
 			// send the dictionary out
@@ -81,7 +81,7 @@ define('/trace/trace_server',function(require){
 		function init(a){
 			var d = []
 			for(var i = 0;i<a.length;i++){
-				if(a[i].charAt(0)==':') d[i] = a[i].slice(1) 
+				if(a[i].charAt(0)==':') d[i] = a[i].slice(1)
 				else d[i] = new RegExp(a[i].slice(1),"i")
 			}
 			return d
@@ -105,7 +105,7 @@ define('/trace/trace_server',function(require){
 
 		f.opt = fspec._opt
 		f.active = _do.length || _no.length
-	
+
 		f.stringify = function(){
 			return JSON.stringify(fspec)
 		}
@@ -123,13 +123,13 @@ define('/trace/trace_server',function(require){
 			define.settingsData = data
 			define.settingsFile = file
 		}
-		catch(e){	
+		catch(e){
 			console.log("Error reading settings file ("+file+") ",e)
 		}
 	}
 
-	if(!loadSettings(path.resolve(process.cwd(),"tracegl.json")) && 
-		!loadSettings("~/tracegl.json") && 
+	if(!loadSettings(path.resolve(process.cwd(),"tracegl.json")) &&
+		!loadSettings("~/tracegl.json") &&
 		!loadSettings(path.resolve(path.dirname(__filename),"tracegl.json")) &&
 		!define.settings)
 		loadSettings(path.resolve(path.dirname(__filename),"tracegl.json"))
@@ -154,6 +154,7 @@ define('/trace/trace_server',function(require){
 			out('  ~c~-do[/:]match ~w~Only trace filenames containing match. Filters -do set first, then -no\n')
 			out('  ~c~-no[/:]match ~w~Ignore filenames containing match. Replace : with / for a regexp, use double escaped \\\\ \n')
 			out('  ~c~-nolib ~w~Short for -no/jquery.* -no:require.js -no/node\\\\_modules \n')
+			out('  ~c~-meteor ~w~Short for -no/jquery.* -no:/packages \n')
 			out('  ~c~-nocatch ~w~Don\'t create exception catching\n')
 			out('  ~c~-bind:0.0.0.0 ~w~Set the hostname to bind our external ports to, default 0.0.0.0\n')
 			out('  ~c~-ui:port ~w~Set trace UI port. default: 2000\n')
@@ -191,7 +192,10 @@ define('/trace/trace_server',function(require){
 					} else {
 						fspec._no.push(a.slice(3))
 					}
-				} else if(a.indexOf('-do') == 0){
+				} else if (a == '-meteor') {
+					fspec._no.push("/jquery.*")
+					fspec._no.push("/packages")
+				}else if(a.indexOf('-do') == 0){
 					fspec._do.push(a.slice(3))
 				} else if(a.indexOf('-settings') == 0){
 					if(fs.existsSync('tracegl.json')){
@@ -272,7 +276,7 @@ define('/trace/trace_server',function(require){
 							console.log("Building file find search db from "+root+" ..")
 							scanHash = {}
 							scan(root, find)
-						} 
+						}
 						else find()
 					} else {
 						var sf = path.resolve(root, sp.join('/'))
@@ -290,7 +294,7 @@ define('/trace/trace_server',function(require){
 	function openEditor(file, line){
 		var ed
 		var s = define.settings
-		if(!s.editors || 
+		if(!s.editors ||
 			!(ed = s.editors[process.platform]))
 			return console.log("No editor settings available for your platform")
 		// lets try all editors
@@ -331,7 +335,7 @@ define('/trace/trace_server',function(require){
 
 		var dict = []
 		var queue = []
-		var joined = false 
+		var joined = false
 
 		var finder = fileFinder(process.cwd())
 
@@ -393,13 +397,13 @@ define('/trace/trace_server',function(require){
 		fstr.on('error', function(err){
 			console.log("Error writing "+file+" "+err)
 		})
-		
+
 		gz.on('error', function(err){
 			console.log("Error zipping "+file+" "+err)
 		})
 
 		gz.pipe(fstr)
-		
+
 		var buf = []
 		var total = 0
 
@@ -459,10 +463,10 @@ define('/trace/trace_server',function(require){
 		tgt.data = function(m, c){
 			sender(m)
 		}
-		
-		var fileCache= {}		
+
+		var fileCache= {}
 		var did = 1 // count instrument offset id
-		
+
 		tgt.fileChange = function(f){
 			// lets flush everything
 			fileCache = {}
@@ -511,7 +515,7 @@ define('/trace/trace_server',function(require){
 		args.unshift(file)
 		args.unshift('-l' + filter.stringify())
 		args.unshift(process.argv[1])
- 		
+
  		var stdio = [process.stdin, process.stdout,'pipe']
  		//if(process.version.indexOf('v0.8') != -1)	stdio.push('ipc')
 
@@ -529,7 +533,7 @@ define('/trace/trace_server',function(require){
 		child.on('message', function(m){
 			sender(m)
 		})
-		
+
 		child.on('exit', function () {
 		    sender(false);
 		})
@@ -549,8 +553,8 @@ define('/trace/trace_server',function(require){
 		tgt.data = function(m, c){
 			sender(m)
 		}
-		
-		var fileCache= {}		
+
+		var fileCache= {}
 		var did = 1 // count instrument offset id
 		tgt.process = function(file, data, type){
 			if(type != "application/javascript") return data
@@ -585,6 +589,7 @@ define('/trace/trace_server',function(require){
 		})
 	}
 })
+
 function define(id,fac){
 //PACKSTART
 	// | returns path of file
@@ -13449,14 +13454,14 @@ define('/trace/trace_client',function(require){
 		ui.drawer()
 	})
 })
-define.settingsData = "{\n\t\"theme\" : \"dark\", // other theme: light\n\t\"ui\":2000, // UI port\n\t\"tgt\":2080, // browser JS port\n\t\"do\":[], // only trace files matching\n\t\"no\":[], // ignore files matching \":match\" for string or \"/match\" for regexp\n\t\"editors\" : { // editor paths per platform, modify these to set up your editor\n\t\t\"darwin\":{\n\t\t\t\"sublime3\":{\n\t\t\t\t\"bin\":\"/Applications/Sublime Text 3.app/Contents/SharedSupport/bin/subl\",\n\t\t\t\t\"args\":[\"$file:$line\"]\n\t\t\t},\n\t\t\t\"sublime2\":{\n\t\t\t\t\"bin\":\"/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl\",\n\t\t\t\t\"args\":[\"$file:$line\"]\n\t\t\t},\n\t\t\t\"textmate\":{\n\t\t\t\t\"bin\":\"/Applications/TextMate.app/Contents/Resources/mate\",\n\t\t\t\t\"args\":[\"$file\",\"--line\",\"$line\"]\n\t\t\t}\n\t\t},\n\t\t\"win32\":{},\n\t\t\"sunos\":{},\n\t\t\"linux\":{},\n\t\t\"freebsd\":{}\n\t}\n}";
+define.settingsData = "{\r\n\t\"theme\" : \"dark\",\r\n\t\"ui\":2000,\r\n\t\"tgt\":2080,\r\n\t\"do\":[],\r\n\t\"no\":[],\r\n\t\"editors\" : {\r\n\t\t\"darwin\":{\r\n\t\t\t\"sublime3\":{\r\n\t\t\t\t\"bin\":\"/Applications/Sublime Text 3.app/Contents/SharedSupport/bin/subl\",\r\n\t\t\t\t\"args\":[\"$file:$line\"]\r\n\t\t\t},\r\n\t\t\t\"sublime2\":{\r\n\t\t\t\t\"bin\":\"/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl\",\r\n\t\t\t\t\"args\":[\"$file:$line\"]\r\n\t\t\t},\r\n\t\t\t\"textmate\":{\r\n\t\t\t\t\"bin\":\"/Applications/TextMate.app/Contents/Resources/mate\",\r\n\t\t\t\t\"args\":[\"$file\",\"--line\",\"$line\"]\r\n\t\t\t}\r\n\t\t},\r\n\t\t\"win32\":{},\r\n\t\t\"sunos\":{},\r\n\t\t\"linux\":{},\r\n\t\t\"freebsd\":{}\r\n\t}\r\n}\r\n";
 define.settings = {
-	"theme" : "dark", // other theme: light
-	"ui":2000, // UI port
-	"tgt":2080, // browser JS port
-	"do":[], // only trace files matching
-	"no":[], // ignore files matching ":match" for string or "/match" for regexp
-	"editors" : { // editor paths per platform, modify these to set up your editor
+	"theme" : "dark",
+	"ui":2000,
+	"tgt":2080,
+	"do":[],
+	"no":[],
+	"editors" : {
 		"darwin":{
 			"sublime3":{
 				"bin":"/Applications/Sublime Text 3.app/Contents/SharedSupport/bin/subl",
@@ -13477,4 +13482,5 @@ define.settings = {
 		"freebsd":{}
 	}
 }
+
 define.factory["/trace/trace_server"](define.mkreq("/trace/trace_server"))


### PR DESCRIPTION
Added **-meteor** option to be used instead of -nolib when tracing Meteor apps.

It simply ignores the "packages" directory, but it wouldn't be correct to add this exclusion to -nolib (as a non-Meteor app may have a folder called "packages" which the dev may not want ignored).

I also **removed the comments** from the settings file (tracegl.json) as the "/" were causing syntax errors.
#### Files with key changes
- trace/trace_server.js
- trace/tracegl.json
